### PR TITLE
#recovery 2 redis db down

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -234,7 +234,17 @@ The handling for the cases that are supported at the moment is described bellow:
    The user is asked to re login ('Login' button is enabled) and reconnect.
    Note - while the server is down the option to send messages is blocked on the client side to prevent data loss. 
    
-2. <b>Redis DB crash</b> - T.B.D.
+2. <b>Redis DB crash</b> - handled on server side and on the client side.
+   The main goal is to prevent a situation in which the end users sending messages that can't be saved to Redis
+   (when required) and even forwarded, since the sender's identity can't be validated using JWT. 
+   
+   Chat Server won't start if Redis DB is unavailable. In case Redis DB becomes unavailable while Chat Server 
+   is running the Chat Server process is terminated, as a result client fails to send the 'connection_alive' event 
+   via websocket (since the session is terminated). Client notifies the user about the situation with an error message -
+   <b>"Error: Chat Server is temporary down. Please re login and re connect."</b>
+   Once Redis DB is available the Chat Server needs to be restarted.
+    
+    
      
 
 

--- a/server_side/authorization_manager.py
+++ b/server_side/authorization_manager.py
@@ -1,6 +1,7 @@
 import jwt
 import logging
 import secrets
+import redis
 
 
 try:
@@ -54,8 +55,13 @@ class AuthManager:
             else:
                 return {"result": "Invalid credentials"}
 
+        except redis.exceptions.RedisError as e:
+            logging.critical(f"Chat Server: Redis DB is unavailable shutting down the server - {e}")
+            raise e
+
         except Exception as e:
             return {"error": f"Authorization module: failed to generate a JWT - {e}"}
+
 
     def validate_jwt_token(self, username, token):
         """

--- a/server_side/authorization_manager.py
+++ b/server_side/authorization_manager.py
@@ -62,7 +62,6 @@ class AuthManager:
         except Exception as e:
             return {"error": f"Authorization module: failed to generate a JWT - {e}"}
 
-
     def validate_jwt_token(self, username, token):
         """
         Validate a given JSON Web Token (JWT) for the specified username.
@@ -76,8 +75,12 @@ class AuthManager:
         :return: Whether the JWT is valid or not.
         :rtype: bool
         """
+        try:
+            return self.redis_integration.validate_user_token(username, token)
 
-        return self.redis_integration.validate_user_token(username, token)
+        except redis.exceptions.RedisError as e:
+            logging.critical(f"Chat Server: Redis DB is unavailable shutting down the server - {e}")
+            raise e
 
     def validate_credentials_for_jwt_creation(self, username, password):
         """

--- a/server_side/chat_server.py
+++ b/server_side/chat_server.py
@@ -7,7 +7,6 @@ import logging
 import os
 import configparser
 import redis
-import sys
 
 
 try:
@@ -56,20 +55,27 @@ class ChatServer:
 
         self.chatgpt_instance = ChatGPTIntegration()
 
+        global emergency_flag
+        emergency_flag = False
+
         # Verifying the ChatGPT service is available
         if self.chatgpt_instance.is_chatgpt_available():
             self.users_currently_online.add(CHAT_GPT_USER)
 
-        self.postgres_integration = PostgresIntegration(config_file_path)
-        self.redis_integration = RedisIntegration(config_file_path)
+        try:
+            self.postgres_integration = PostgresIntegration(config_file_path)
+            self.redis_integration = RedisIntegration(config_file_path)
 
-        self.users_list = self.postgres_integration.get_all_available_users_list()
-        self.auth_manager = AuthManager(self.postgres_integration, self.redis_integration)
+            self.users_list = self.postgres_integration.get_all_available_users_list()
+            self.auth_manager = AuthManager(self.postgres_integration, self.redis_integration)
 
-        # Consider - deleting ALL existing tokens from Redis ON START, publish DISCONNECTION event for each user
-        # in order to handle Chat Server crash (stop-start)
-        global emergency_flag
-        emergency_flag = False
+        # The Chat Service won't start unless Redis DB is available.
+        except redis.exceptions.ConnectionError as e:
+            logging.critical(f"Redis server isn't available - Chat Server goes down. "
+                             f"Please make sure Redis DB is up'{e}")
+
+            # Redis unavailable - activating the emergency flag.
+            emergency_flag = True
 
     def room_names_generator(self, listed_users: list) -> list:
         """
@@ -185,6 +191,14 @@ class ChatServer:
             logging.error(f"Failed to publish cached messages to user {user_name} - {e}")
             return False
 
+    def stop_chat_server_because_redis_down(self, e):
+        logging.critical(f" Alert! Redis DB is down - {e}")
+        logging.critical(f"Chat server is going down to prevent further data loss")
+        logging.critical(f"Please make sure Redis DB is up and running. "
+                         f"After that please RESTART the Chat Server instance.")
+        self.socketio.stop()
+
+
     def run(self):
         """
         This method handles incoming HTTP requests and websocket messages
@@ -215,10 +229,14 @@ class ChatServer:
 
             logging.info(f"Received a request for contacts, username: '{user_name}',  JWT: {jwt_token}")
 
-            # Validating JWT before allowing the user to get the contacts list
-            if not self.auth_manager.validate_jwt_token(user_name, jwt_token):
-                logging.error(f"Invalid JWT: {jwt_token}")
-                return {"error": "Invalid JWT"}
+            try:
+                # Validating JWT before allowing the user to get the contacts list
+                if not self.auth_manager.validate_jwt_token(user_name, jwt_token):
+                    logging.error(f"Invalid JWT: {jwt_token}")
+                    return {"error": "Invalid JWT"}
+
+            except redis.exceptions.ConnectionError as e:
+                self.stop_chat_server_because_redis_down(e)
 
             contacts_data = {"contacts": self.prepare_rooms_for(username),
                              "currently_online": list(self.users_currently_online),
@@ -238,9 +256,6 @@ class ChatServer:
 
             :return: dict
             """
-            # if emergency_flag:
-            #     return {"error": "System was stopped due to a critical error. "
-            #                      "Log in is blocked until the issue is resolved."}
 
             request_content = request.get_json()
 
@@ -251,8 +266,13 @@ class ChatServer:
             except KeyError:
                 return {"error": "Invalid Log In request"}
 
-            logging.info(f"New log in request received, username: {username}, password: {password}")
-            requested_token = self.auth_manager.generate_jwt_token(username, password)
+            try:
+                logging.info(f"New log in request received, username: {username}, password: {password}")
+                requested_token = self.auth_manager.generate_jwt_token(username, password)
+
+            except redis.exceptions.ConnectionError as e:
+                self.stop_chat_server_because_redis_down(e)
+                return {"result": "error", "token": "unavailable"}
 
             return requested_token
 
@@ -324,8 +344,13 @@ I           If the token generation is successful, the code removes the JWT toke
             except KeyError as e:
                 return {"error": f"Invalid request, missing required field: {e}"}
 
-            logging.info(f"Admin user request received, username: {username}, password: {password}")
-            requested_token = self.auth_manager.generate_jwt_token(username, password)
+            try:
+                logging.info(f"Admin user request received, username: {username}, password: {password}")
+                requested_token = self.auth_manager.generate_jwt_token(username, password)
+
+            except redis.exceptions.ConnectionError as e:
+                self.stop_chat_server_because_redis_down(e)
+                return
 
             if requested_token['result'] == 'success':
                 return {"online_clients_list": list(self.users_currently_online)}
@@ -366,10 +391,15 @@ I           If the token generation is successful, the code removes the JWT toke
                 logging.error(f"Invalid request, missing required field: {e}")
                 return {"error": f"Invalid request, missing required field: {e}"}
 
-            # Validating JWT before allowing the user to JOIN
-            if not self.auth_manager.validate_jwt_token(client_name, client_token):
-                logging.error(f"Invalid JWT: {client_token}")
-                return {"error": "Invalid JWT"}
+            try:
+                # Validating JWT before allowing the user to JOIN
+                if not self.auth_manager.validate_jwt_token(client_name, client_token):
+                    logging.error(f"Invalid JWT: {client_token}")
+                    return {"error": "Invalid JWT"}
+
+            except redis.exceptions.ConnectionError as e:
+                self.stop_chat_server_because_redis_down(e)
+                return {"result": "error"}
 
             logging.info(f"Users currently online: {list(self.users_currently_online)}")
 
@@ -459,9 +489,10 @@ I           If the token generation is successful, the code removes the JWT toke
                     return send_message(client_name, content, conversation_room)
 
             except redis.exceptions.ConnectionError as e:
-                logging.critical(f"Redis is dead! Killing all! {e}")
-                # global emergency_flag
-                # emergency_flag = True
+                logging.critical(f" Alert! Redis DB is down - {e}")
+                logging.critical(f"Chat server is going down to prevent further data loss")
+                logging.critical(f"Please make sure Redis DB is up and running. "
+                                 f"After that please RESTART the Chat Server instance.")
                 self.socketio.stop()
 
         def send_message(sender, content, conversation_room):
@@ -536,11 +567,15 @@ I           If the token generation is successful, the code removes the JWT toke
                 logging.error(f"Invalid message, missing required fields: {e}")
                 return {"error": f"Invalid message, missing required fields: {e}"}
 
-            # Invalid JWT token in client message
-            if not self.auth_manager.validate_jwt_token(client_name, client_token):
-                logging.warning(f"Caution! An unauthorized disconnection attempt was just "
-                                f"performed for user {client_name}!")
-                return
+            try:
+                # Invalid JWT token in client message
+                if not self.auth_manager.validate_jwt_token(client_name, client_token):
+                    logging.warning(f"Caution! An unauthorized disconnection attempt was just "
+                                    f"performed for user {client_name}!")
+                    return
+
+            except redis.exceptions.ConnectionError as e:
+                self.stop_chat_server_because_redis_down(e)
 
             if client_name in self.users_currently_online:
                 self.users_currently_online.remove(client_name)
@@ -661,7 +696,10 @@ def connection_checker(chat_instance: ChatServer):
 
 if __name__ == '__main__':
     my_chat_server = ChatServer()
-    connection_verification_thread = threading.Thread(target=connection_checker, args=(my_chat_server,))
-    connection_verification_thread.start()
-    my_chat_server.run()
+
+    # Not starting the service if the emergency flag is up.
+    if emergency_flag is False:
+        connection_verification_thread = threading.Thread(target=connection_checker, args=(my_chat_server,))
+        connection_verification_thread.start()
+        my_chat_server.run()
 

--- a/server_side/chat_server.py
+++ b/server_side/chat_server.py
@@ -7,6 +7,8 @@ import logging
 import os
 import configparser
 import redis
+import signal
+
 
 
 try:
@@ -196,6 +198,11 @@ class ChatServer:
         logging.critical(f"Chat server is going down to prevent further data loss")
         logging.critical(f"Please make sure Redis DB is up and running. "
                          f"After that please RESTART the Chat Server instance.")
+
+        # If running in a Docker container - killing the Chat Serer process by process ID
+        if os.getenv("KEEP_ALIVE_DELAY_BETWEEN_EVENTS"):
+            os.kill(1, signal.SIGTERM)
+
         self.socketio.stop()
 
 
@@ -493,6 +500,11 @@ I           If the token generation is successful, the code removes the JWT toke
                 logging.critical(f"Chat server is going down to prevent further data loss")
                 logging.critical(f"Please make sure Redis DB is up and running. "
                                  f"After that please RESTART the Chat Server instance.")
+
+                # If running in a Docker container  - killing the main Chat Server process.
+                if os.getenv("KEEP_ALIVE_DELAY_BETWEEN_EVENTS"):
+                    os.kill(1, signal.SIGTERM)
+
                 self.socketio.stop()
 
         def send_message(sender, content, conversation_room):

--- a/server_side/redis_integration.py
+++ b/server_side/redis_integration.py
@@ -16,6 +16,13 @@ class RedisIntegration:
         try:
             self.read_config(config_file_path)
             self.redis_client = redis.Redis(host=self.hst, port=REDIS_PORT, db=self.db_number)
+            all_keys = self.redis_client.keys('*')
+
+            logging.info(f'Existing keys: {all_keys}')
+
+        except redis.exceptions.ConnectionError as e:
+            logging.critical(f"Failed to establish a connection with the Redis server: {e}")
+            raise e
 
         except Exception as e:
             logging.critical(f"Redis integration: Error! Failed to connect to Redis DB container - {e}")
@@ -156,7 +163,7 @@ class RedisIntegration:
             self.redis_client.hdel(self.redis_jwt_hashmap_name, username)
             return True
 
-        except redis.exceptions.RedisError as e:
+        except (redis.exceptions.RedisError, redis.exceptions.ConnectionError) as e:
             logging.error(f"Redis Integration: Redis Error! - {e}")
             raise e
 


### PR DESCRIPTION
Handling the following emergency situations:
1. Redis DB is unavailable when Chat Server starts. 
2. Redis DB <b>becomes</b> unavailable while Chat Server is running. 

 The main goal is to prevent a situation in which the end users send messages that can't be saved to Redis
 (when required) and even forwarded, since the sender's identity can't be validated using JWT. 

Server side handling: 
+ Chat Server won't start if Redis DB is unavailable
+ Chat Server will stop in case Redis DB becomes unavailable. 

Client side handling:
+ If 'connection_alive' event can't be send because  websocket session is terminated assume that the Chat Server 
 is down
+ Prevent from user to send messages to other users via UI
+ Prevent from user to send a connection request via UI 
+ Present a relevant error message to a user. 
   